### PR TITLE
Moved to Secure websocket and moved to base wss url - production ready

### DIFF
--- a/renderer/app.js
+++ b/renderer/app.js
@@ -34,7 +34,7 @@ async function loadConfig() {
         document.getElementById('target-address-settings').value = config.targetOscAddress;
         const serverUrlInput = document.getElementById('server-url-settings');
         if (serverUrlInput) {
-            serverUrlInput.value = config.websocketServerUrl || 'ws://localhost:48255';
+            serverUrlInput.value = config.websocketServerUrl || 'wss://avatar.comfychloe.uk:48255';
         }
         if (config.additionalOscConnections) {
             additionalOscConnections = config.additionalOscConnections;

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -87,7 +87,7 @@
                 <h3>Server Configuration</h3>
                 <div class="form-group">
                     <label for="server-url-settings">WebSocket Server URL</label>
-                    <input type="text" id="server-url-settings" value="ws://localhost:48255">
+                    <input type="text" id="server-url-settings" value="wss://avatar.comfychloe.uk:48255">
                 </div>
                 <button class="btn btn-primary" onclick="updateConfigFromSettings()">Update Server Config</button>
             </div>

--- a/utils/configManager.js
+++ b/utils/configManager.js
@@ -10,7 +10,7 @@ class ConfigManager {
       targetOscPort: 9000,
       targetOscAddress: '127.0.0.1',
       additionalOscConnections: [],
-      websocketServerUrl: 'ws://localhost:48255',
+      websocketServerUrl: 'wss://avatar.comfychloe.uk:48255',
       autoConnect: false,
       logLevel: 'info',
       appSettings: {

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -1,13 +1,14 @@
 const path = require('path');
 const fs = require('fs');
+const { app } = require('electron');
 class Logger {
   constructor() {
-    this.logDir = path.join(__dirname, '..', 'logs');
+    this.logDir = path.join(app.getPath('userData'), 'logs');
     this.ensureLogDirectory();
   }
   ensureLogDirectory() {
     if (!fs.existsSync(this.logDir)) {
-      fs.mkdirSync(this.logDir);
+      fs.mkdirSync(this.logDir, { recursive: true });
     }
   }
   logError(error) {

--- a/utils/oscService.js
+++ b/utils/oscService.js
@@ -191,26 +191,32 @@ class OscService extends EventEmitter {
     }
   }
   stop() {
-    if (this.primaryUdpPort && this.isListening) {
+    if (this.primaryUdpPort && this.isListening && this.primaryUdpPort._handle) {
       try {
         this.primaryUdpPort.close();
       } catch (error) {
-        this.emit('error', error);
+        if (error.code !== 'ERR_SOCKET_DGRAM_NOT_RUNNING') {
+          this.emit('error', error);
+        }
       }
     }
     this.additionalPorts.forEach((portData) => {
-      if (portData.server) {
+      if (portData.server && portData.server._handle) {
         try {
           portData.server.close();
         } catch (err) {
-          console.warn('Error closing additional server:', err);
+          if (err.code !== 'ERR_SOCKET_DGRAM_NOT_RUNNING') {
+            console.error('Error closing additional server:', err);
+          }
         }
       }
-      if (portData.client) {
+      if (portData.client && portData.client._handle) {
         try {
           portData.client.close();
         } catch (err) {
-          console.warn('Error closing additional client:', err);
+          if (err.code !== 'ERR_SOCKET_DGRAM_NOT_RUNNING') {
+            console.error('Error closing additional client:', err);
+          }
         }
       }
     });


### PR DESCRIPTION
This pull request updates the application's default WebSocket server URL to a secure, production endpoint and improves error handling and resource management throughout the codebase. It also enhances the logging system to ensure logs are stored in the user's data directory and safely manages log directory creation. Additionally, it introduces more robust cleanup logic for OSC and WebSocket connections.

**Default WebSocket Server URL and Configuration Updates:**

* Changed the default `websocketServerUrl` and related UI fields from `ws://localhost:48255` to the secure production endpoint `wss://avatar.comfychloe.uk:48255` in `configManager.js`, `index.html`, `app.js`, and `websocketManager.js`. [[1]](diffhunk://#diff-4e434ba7194d35a8169f164386243a125cc5bf1ad7d822066619dc57411fe395L13-R13) [[2]](diffhunk://#diff-4eed4839430cd72faae8ae7a45a1942ad026f3149903c4dde8d9d64cb5607c0eL90-R90) [[3]](diffhunk://#diff-f148d37afdad77c5ef7570828c4f142f07ff3975433237a96524c3fa0f7941d2L37-R37) [[4]](diffhunk://#diff-93b9fb8ed78aad537d6192bcdbd5688940a0882d2616367a0bbc7d6d6e091c6bL9-R9)
* Updated WebSocket connection options to explicitly set `secure`, `rejectUnauthorized`, and `forceNew` based on the URL scheme.

**Logging Improvements:**

* Modified `logger.js` to store logs in the Electron user data directory instead of a relative path, and to create the log directory recursively if it doesn't exist.

**OSC Service Resource Management:**

* Enhanced the OSC service's `stop` method to check for valid socket handles before closing, and to suppress expected socket errors while logging unexpected ones.

**WebSocket Error Handling:**

* Added detailed error logging for WebSocket connection failures, including connection details and error context, and improved logging on reconnection attempts. [[1]](diffhunk://#diff-93b9fb8ed78aad537d6192bcdbd5688940a0882d2616367a0bbc7d6d6e091c6bR61-R71) [[2]](diffhunk://#diff-93b9fb8ed78aad537d6192bcdbd5688940a0882d2616367a0bbc7d6d6e091c6bR102-R107)