### PR TITLE
Bugfix ARC Logo not represented on splashscreen

### DIFF
--- a/main.js
+++ b/main.js
@@ -79,7 +79,7 @@ function createWindow() {
       enableRemoteModule: false,
       preload: path.join(__dirname, 'preload.js')
     },
-    icon: path.join(__dirname, 'assets', 'icon.png'),
+    icon: path.join(__dirname, 'Assets', 'ARC.ico'),
     title: 'ARC-OSC Client',
     show: false // Start hidden so we can control when it appears
   })

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
       "renderer/**/*",
       "utils/**/*",
       "Containers/**/*",
+      "Assets/**/*",
       "secrets.json",
       "package.json",
       "!node_modules/**/*.md",
@@ -61,7 +62,7 @@
     ],
     "win": {
       "target": "portable",
-      "icon": "assets/ARC.ico"
+      "icon": "Assets/ARC.ico"
     },
     "compression": "maximum",
     "nsis": {


### PR DESCRIPTION
This pull request updates the application's icon path references and ensures the new `Assets` directory is included in the build. The changes are primarily focused on standardizing the icon location and updating build configurations for Windows.

**Asset path updates:**

* Changed the icon path in `main.js` to use `Assets/ARC.ico` instead of `assets/icon.png`, ensuring consistency with the new asset directory and icon file.

**Build configuration updates:**

* Added the `Assets` directory to the included files list in `package.json` to ensure all necessary assets are packaged.
* Updated the Windows build configuration in `package.json` to use the new icon path `Assets/ARC.ico` instead of `assets/ARC.ico`.